### PR TITLE
Add an example with a counter and wrap config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,6 +9,7 @@
   "customizations": {
     "codespaces": {
       "openFiles": [
+        "example/main.dart",
         "README.md",
         "CONTRIBUTING.md",
         "CODE_OF_CONDUCT.md"

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Call the `Cosim.connectToSimulation` function with an appropriate configuration 
 ### Additional information
 - Note that for cosimulation to execute, the ROHD `Simulator` must be running.
 - Note that with the cosimulation process running in a unit test suite, you have an additional thing to reset each `tearDown`: `Cosim.reset()`.
+- The `example/` directory has a counter example similar to what's available in the ROHD and ROHD-VF examples.
 - The ROHD Cosim test suite in `test/` is a good reference for some examples of how to set things up.
 
 ##  Cosimulation Configurations
@@ -100,6 +101,8 @@ Pass a `CosimWrapConfig` object into the `Cosim.connectToSimulation` call with i
 The below diagram shows how the wrap configuration connects to your simulation.  ROHD will generate a Makefile and connector for your design, and then connect to it by listening to some port information coming through stdout from the simulation process.
 
 ![Wrap Config Diagram](https://github.com/intel/rohd-cosim/raw/main/doc/diagrams/wrap.png)
+
+The example in `example/main.dart` uses the wrap configuration and is a good reference to get started.
 
 ### Custom Configuration
 

--- a/example/counter.sv
+++ b/example/counter.sv
@@ -1,0 +1,27 @@
+/**
+ * This file was generated using the ROHD example:
+ * https://github.com/intel/rohd/blob/main/example/example.dart
+ */
+
+ module Counter(
+    input logic en,
+    input logic reset,
+    input logic clk,
+    output logic [7:0] val
+    );
+    logic [7:0] nextVal;
+    //  sequential
+    always_ff @(posedge clk) begin
+      if(reset) begin
+          val <= 8'h0;
+      end else begin
+          if(en) begin
+              val <= nextVal;
+          end 
+    
+      end 
+    
+    end
+    
+    assign nextVal = val + 8'h1;  // add
+endmodule : Counter

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,0 +1,129 @@
+/// Copyright (C) 2023 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// main.dart
+/// Example of using a `CosimWrapConfig` with ROHD Cosim.
+///
+/// 2023 February 13
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+// ignore_for_file: avoid_print
+
+// Import the ROHD package.
+import 'package:rohd/rohd.dart';
+
+// Import the ROHD Cosim package.
+import 'package:rohd_cosim/rohd_cosim.dart';
+
+// Define a class Counter that extends ROHD's abstract
+// `ExternalSystemVerilogModule` class and add the `Cosim` mixin.
+class Counter extends ExternalSystemVerilogModule with Cosim {
+  // For convenience, map interesting outputs to short variable names for
+  // consumers of this module.
+  Logic get val => output('val');
+
+  // This counter was written with 8-bit width.
+  static const int width = 8;
+
+  // We must provide instructions for where to find the SystemVerilog that
+  // is used to build the wrapped module.
+  // Note that the path is relative to where we will configure the SystemVerilog
+  // simulator to be running.
+  @override
+  List<String>? get verilogSources => ['../counter.sv'];
+
+  Counter(Logic en, Logic reset, Logic clk, {super.name = 'counter'})
+      // The `definitionName` is the name of the SystemVerilog module
+      // we're instantiating.
+      : super(definitionName: 'Counter') {
+    // Register inputs and outputs of the module in the constructor.
+    // These name *must* match the names of the ports in the SystemVerilog
+    // module that we are wrapping.
+    en = addInput('en', en);
+    reset = addInput('reset', reset);
+    clk = addInput('clk', clk);
+    addOutput('val', width: width);
+  }
+}
+
+// Let's simulate with this counter a little, generate a waveform, and take a
+// look at generated SystemVerilog.  This little simulation mirrors closely the
+// original example from ROHD:
+// https://github.com/intel/rohd/blob/main/example/example.dart
+Future<void> main({bool noPrint = false}) async {
+  // Define some local signals.
+  final en = Logic(name: 'en');
+  final reset = Logic(name: 'reset');
+
+  // Generate a simple clock.  This will run along by itself as
+  // the Simulator goes.
+  final clk = SimpleClockGenerator(10).clk;
+
+  // Make our cosimulated counter.
+  final counter = Counter(en, reset, clk);
+
+  // Before we can simulate or generate code with the counter, we need
+  // to build it.
+  await counter.build();
+
+  // **Important for Cosim!**
+  // We must connect to the cosimulation process with configuration information.
+  await Cosim.connectCosimulation(CosimWrapConfig(
+    // The SystemVerilog will simulate with Icarus Verilog
+    SystemVerilogSimulator.icarus,
+
+    // We can generate waves from the SystemVerilog simulator.
+    dumpWaves: !noPrint,
+
+    // Let's specify where we want our SystemVerilog simulation to run.
+    // This is the directory where temporary files, waves, and output
+    // logs may appear.
+    directory: './example/tmp_cosim/',
+  ));
+
+  // Now let's try simulating!
+
+  // Let's start off with a disabled counter and asserting reset.
+  en.inject(0);
+  reset.inject(1);
+
+  // Attach a waveform dumper so we can see what happens in the ROHD simulator.
+  // Note that this is a separate VCD file from what the SystemVerilog simulator
+  // will dump out.
+  if (!noPrint) {
+    WaveDumper(counter, outputPath: './example/tmp_cosim/rohd_waves.vcd');
+  }
+
+  // Drop reset at time 25.
+  Simulator.registerAction(25, () => reset.put(0));
+
+  // Raise enable at time 45.
+  Simulator.registerAction(45, () => en.put(1));
+
+  // Print a message every time the counter value changes.
+  counter.val.changed.listen((event) {
+    if (!noPrint) {
+      print('Value of the counter changed @${Simulator.time}: $event');
+    }
+  });
+
+  // Print a message when we're done with the simulation!
+  Simulator.registerAction(100, () {
+    if (!noPrint) {
+      print('Simulation completed!');
+    }
+  });
+
+  // Set a maximum time for the simulation so it doesn't keep running forever.
+  Simulator.setMaxSimTime(100);
+
+  // Kick off the simulation.
+  await Simulator.run();
+
+  // We can take a look at the waves now.
+  if (!noPrint) {
+    print('To view waves, check out waves with a waveform viewer'
+        ' (e.g. `gtkwave waves.vcd` and `gtkwave rohd_waves.vcd`).');
+  }
+}

--- a/test/example_test.dart
+++ b/test/example_test.dart
@@ -1,0 +1,29 @@
+/// Copyright (C) 2023 Intel Corporation
+/// SPDX-License-Identifier: BSD-3-Clause
+///
+/// example_test.dart
+/// Tests to make sure that the examples don't break.
+///
+/// 2023 February 13
+/// Author: Max Korbel <max.korbel@intel.com>
+///
+
+import 'dart:io';
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd_cosim/rohd_cosim.dart';
+import 'package:test/test.dart';
+
+import '../example/main.dart' as counter;
+
+void main() {
+  tearDown(() async {
+    await Simulator.reset();
+    await Cosim.reset();
+  });
+
+  test('counter example', () async {
+    await counter.main(noPrint: true);
+    Directory('./example/tmp_cosim').deleteSync(recursive: true);
+  });
+}


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

It's helpful to provide a full, running example.  This PR adds a counter example, similar to what's provided in ROHD and ROHD-VF.  It cosimulates with a SystemVerilog counter.

## Related Issue(s)

Fix #17 

## Testing

Added a test that runs the example to protect it.  Also, reviewed waves generated by the example.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Yes, updated README to reference the new example