### PR TITLE
More robust test cleanup

### DIFF
--- a/test/bus_test.dart
+++ b/test/bus_test.dart
@@ -49,6 +49,6 @@ Future<void> main() async {
     ];
     await SimCompare.checkFunctionalVector(mod, vectors);
 
-    CosimTestingInfrastructure.cleanupCosim(dirName);
+    await CosimTestingInfrastructure.cleanupCosim(dirName);
   });
 }

--- a/test/cosim_test.dart
+++ b/test/cosim_test.dart
@@ -209,6 +209,6 @@ Future<void> main() async {
     expect(File('tmp_cosim/simple_push_n_check_w_waves/waves.vcd').existsSync(),
         isTrue);
 
-    CosimTestingInfrastructure.cleanupCosim(dirName);
+    await CosimTestingInfrastructure.cleanupCosim(dirName);
   });
 }

--- a/test/cosim_test_infra.dart
+++ b/test/cosim_test_infra.dart
@@ -47,14 +47,23 @@ class CosimTestingInfrastructure {
 
     if (cleanupAfterSimulationEnds) {
       // wait a second to do it so that the SV simulator can shut down
-      unawaited(Simulator.simulationEnded.then((_) =>
-          Future<void>.delayed(const Duration(seconds: 1))
-              .then((_) => cleanupCosim(testName))));
+      unawaited(Simulator.simulationEnded.then((_) => cleanupCosim(testName)));
     }
   }
 
   /// Deletes temporary files created by [connectCosim].
-  static void cleanupCosim(String testName) {
-    Directory('$_tmpCosimDir/$testName').deleteSync(recursive: true);
+  static Future<void> cleanupCosim(String testName) async {
+    await delayedDeleteDirectory('$_tmpCosimDir/$testName');
+  }
+
+  /// Deletes a directory at [directoryPath] (recursively) after
+  /// [delay] seconds.
+  static Future<void> delayedDeleteDirectory(String directoryPath,
+      {int delay = 1}) async {
+    await Future<void>.delayed(const Duration(seconds: 1));
+    final dir = Directory(directoryPath);
+    if (dir.existsSync()) {
+      dir.deleteSync(recursive: true);
+    }
   }
 }

--- a/test/example_test.dart
+++ b/test/example_test.dart
@@ -8,13 +8,12 @@
 /// Author: Max Korbel <max.korbel@intel.com>
 ///
 
-import 'dart:io';
-
 import 'package:rohd/rohd.dart';
 import 'package:rohd_cosim/rohd_cosim.dart';
 import 'package:test/test.dart';
 
 import '../example/main.dart' as counter;
+import 'cosim_test_infra.dart';
 
 void main() {
   tearDown(() async {
@@ -24,6 +23,7 @@ void main() {
 
   test('counter example', () async {
     await counter.main(noPrint: true);
-    Directory('./example/tmp_cosim').deleteSync(recursive: true);
+    await CosimTestingInfrastructure.delayedDeleteDirectory(
+        './example/tmp_cosim');
   });
 }

--- a/test/ff_test.dart
+++ b/test/ff_test.dart
@@ -55,6 +55,6 @@ Future<void> main() async {
     ];
     await SimCompare.checkFunctionalVector(mod, vectors);
 
-    CosimTestingInfrastructure.cleanupCosim(dirName);
+    await CosimTestingInfrastructure.cleanupCosim(dirName);
   });
 }

--- a/test/finish_test.dart
+++ b/test/finish_test.dart
@@ -52,6 +52,6 @@ Future<void> main() async {
     // expect the unexpected
     expect(unexpectedEnd, isTrue);
 
-    CosimTestingInfrastructure.cleanupCosim(dirName);
+    await CosimTestingInfrastructure.cleanupCosim(dirName);
   });
 }

--- a/test/hier_test.dart
+++ b/test/hier_test.dart
@@ -15,6 +15,8 @@ import 'package:rohd/src/utilities/simcompare.dart';
 import 'package:rohd_cosim/rohd_cosim.dart';
 import 'package:test/test.dart';
 
+import 'cosim_test_infra.dart';
+
 class BottomMod extends ExternalSystemVerilogModule with Cosim {
   @override
   String get cosimHierarchy => 'submod';
@@ -31,19 +33,18 @@ void main() {
   const hierStuffDir = './test/hier_stuff/';
   const outDirPath = '$hierStuffDir/tmp_output/';
 
-  void cleanup() {
-    final outDir = Directory(outDirPath);
-    if (outDir.existsSync()) {
-      outDir.deleteSync(recursive: true);
-    }
+  Future<void> cleanup() async {
+    await CosimTestingInfrastructure.delayedDeleteDirectory(outDirPath);
   }
 
-  setUp(cleanup);
+  setUp(() async {
+    await cleanup();
+  });
 
   tearDown(() async {
     await Simulator.reset();
     await Cosim.reset();
-    cleanup();
+    await cleanup();
   });
 
   test('hier test', () async {

--- a/test/pair_test.dart
+++ b/test/pair_test.dart
@@ -15,6 +15,8 @@ import 'package:rohd/rohd.dart';
 import 'package:rohd_cosim/rohd_cosim.dart';
 import 'package:test/test.dart';
 
+import 'cosim_test_infra.dart';
+
 enum PairDirection { leftToRight, rightToLeft, misc }
 
 class PairInterface extends Interface<PairDirection> {
@@ -71,19 +73,18 @@ void main() async {
   const pairStuffDir = './test/pair_stuff/';
   const outDirPath = '$pairStuffDir/tmp_output/';
 
-  void cleanup() {
-    final outDir = Directory(outDirPath);
-    if (outDir.existsSync()) {
-      outDir.deleteSync(recursive: true);
-    }
+  Future<void> cleanup() async {
+    await CosimTestingInfrastructure.delayedDeleteDirectory(outDirPath);
   }
 
-  setUp(cleanup);
+  setUp(() async {
+    await cleanup();
+  });
 
   tearDown(() async {
-    await Cosim.reset();
     await Simulator.reset();
-    cleanup();
+    await Cosim.reset();
+    await cleanup();
   });
 
   test('pair test', () async {

--- a/test/port_test.dart
+++ b/test/port_test.dart
@@ -18,18 +18,16 @@ import 'package:rohd/rohd.dart';
 import 'package:rohd_cosim/rohd_cosim.dart';
 import 'package:test/test.dart';
 
+import 'cosim_test_infra.dart';
 import 'port_stuff/port_launch.dart';
 
 void main() async {
   const portStuffDir = './test/port_stuff/';
   String outDirPathOf(String outDirName) => '$portStuffDir/$outDirName/';
 
-  void cleanup(String outDirName) {
+  Future<void> cleanup(String outDirName) async {
     final outDirPath = outDirPathOf(outDirName);
-    final outDir = Directory(outDirPath);
-    if (outDir.existsSync()) {
-      outDir.deleteSync(recursive: true);
-    }
+    await CosimTestingInfrastructure.delayedDeleteDirectory(outDirPath);
   }
 
   tearDown(() async {
@@ -46,7 +44,7 @@ void main() async {
     bool failAsync = false,
     bool hang = false,
   }) async {
-    cleanup(outDirName);
+    await cleanup(outDirName);
 
     final runEnv = {
       'OUT_DIR': outDirName,
@@ -103,7 +101,7 @@ void main() async {
 
     expect(stdoutContents, contains('PASS=1'));
 
-    cleanup(outDirName);
+    await cleanup(outDirName);
   });
 
   test('port test dart fail', () async {
@@ -123,7 +121,7 @@ void main() async {
     // make sure error is communicated
     expect(stdoutContents, contains('ERROR:'));
 
-    cleanup(outDirName);
+    await cleanup(outDirName);
   });
 
   test('port test with finish passes', () async {
@@ -134,7 +132,7 @@ void main() async {
 
     expect(stdoutContents, contains('detected a failure from cocotb'));
 
-    cleanup(outDirName);
+    await cleanup(outDirName);
   });
 
   test('port test dart fail async', () async {
@@ -154,7 +152,7 @@ void main() async {
     // make sure error is communicated
     expect(stdoutContents, contains('ERROR:'));
 
-    cleanup(outDirName);
+    await cleanup(outDirName);
   });
 
   test('port test dart hang timeout', () async {
@@ -168,6 +166,6 @@ void main() async {
     // make sure error is communicated
     expect(stdoutContents, contains('ERROR:'));
 
-    cleanup(outDirName);
+    await cleanup(outDirName);
   });
 }

--- a/test/sampling_test.dart
+++ b/test/sampling_test.dart
@@ -90,6 +90,6 @@ void main() {
       );
     }
 
-    CosimTestingInfrastructure.cleanupCosim(dirName);
+    await CosimTestingInfrastructure.cleanupCosim(dirName);
   });
 }

--- a/test/timing_test.dart
+++ b/test/timing_test.dart
@@ -88,7 +88,7 @@ void main() {
       VcdParser.confirmValue(vcdContents, 'reset', vcdTime, expectedResetValue);
     }
 
-    CosimTestingInfrastructure.cleanupCosim(dirName);
+    await CosimTestingInfrastructure.cleanupCosim(dirName);
   });
 
   test('inject on edge shows up on same edge', () async {
@@ -128,7 +128,7 @@ void main() {
     expect(VcdParser.confirmValue(vcdContents, 'reset', 20000, LogicValue.zero),
         isTrue);
 
-    CosimTestingInfrastructure.cleanupCosim(dirName);
+    await CosimTestingInfrastructure.cleanupCosim(dirName);
   });
 
   test('initially driven signals show up properly', () async {
@@ -154,6 +154,6 @@ void main() {
 
     await Simulator.run();
 
-    CosimTestingInfrastructure.cleanupCosim(dirName);
+    await CosimTestingInfrastructure.cleanupCosim(dirName);
   });
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

There were some rare failures coming out of the test suite that appeared to be related to the SystemVerilog simulator generating files after the Dart test ended.  This PR adds some delay during cleanup of temporary directories and makes tests more consistent in their cleanup approach to reduce the chance of hitting this type of spurious failure.

## Related Issue(s)

N/A

## Testing

Fixed/updated tests and ran all, plus checked that tmp directories were cleared.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No