### PR TITLE
Support for `LogicArray` ports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ The [ROHD Forum](https://intel.github.io/rohd-website/forum/rohd-forum/) is a pe
 You must have [Dart](https://dart.dev/) installed on your system to use ROHD and ROHD Cosim. You can find detailed instructions for how to install Dart here:
 <https://dart.dev/get-dart>
 
-To run the complete ROHD Cosim test suite for development, you need to install [Icarus Verilog](http://iverilog.icarus.com/). It is used as the SystemVerilog simulator side of the cosimulation. Installation instructions are available here: <https://iverilog.fandom.com/wiki/Installation_Guide>
+To run the complete ROHD Cosim test suite for development, you need to install [Icarus Verilog](https://steveicarus.github.io/iverilog/). It is used as the SystemVerilog simulator side of the cosimulation. Installation instructions are available here: <https://iverilog.fandom.com/wiki/Installation_Guide>
 
 ROHD Cosim relies on a python package called [cocotb](https://docs.cocotb.org/en/stable/) and its GPI library for communicating to SystemVerilog simulators.  The cocotb libraries have good support for a variety of simulators and have been used by many silicon and FPGA projects. You will need to have a sufficiently recent version of [Python](https://www.python.org/) installed.  Detailed instructions for installing cocotb are available here: <https://docs.cocotb.org/en/stable/install.html>.  The instructions generally boil down to:
 

--- a/lib/src/configs/cosim_wrap_config.dart
+++ b/lib/src/configs/cosim_wrap_config.dart
@@ -135,6 +135,7 @@ class CosimWrapConfig extends CosimProcessConfig {
           registreeEntry.value.instantiationVerilog(
             'dont_care',
             registreeEntry.key,
+            // ignore: invalid_use_of_protected_member
             registreeEntry.value.inputs.map((key, value) => MapEntry(key, '')),
             registreeEntry.value.outputs.map((key, value) => MapEntry(key, '')),
           )),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
   sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
+  collection: ^1.18.0
   logging: ^1.0.2
   meta: ^1.8.0
   rohd: ^0.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,12 +7,12 @@ issue_tracker: https://github.com/intel/rohd-cosim/issues
 documentation: https://intel.github.io/rohd-cosim/rohd_cosim/rohd_cosim-library.html
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dependencies:
   logging: ^1.0.2
   meta: ^1.8.0
-  rohd: ^0.4.2
+  rohd: ^0.5.0
   synchronized: ^3.0.0
 
 dev_dependencies:

--- a/test/array_test.dart
+++ b/test/array_test.dart
@@ -1,0 +1,93 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// array_test.dart
+// Tests for array functionality
+//
+// 2023 November 28
+// Author: Max Korbel <max.korbel@intel.com>
+
+import 'package:rohd/rohd.dart';
+import 'package:rohd/src/utilities/simcompare.dart';
+import 'package:rohd_cosim/rohd_cosim.dart';
+import 'package:test/test.dart';
+
+import 'cosim_test_infra.dart';
+
+class CosimArrayMod extends ExternalSystemVerilogModule with Cosim {
+  LogicArray get b => output('b') as LogicArray;
+
+  @override
+  List<String> get verilogSources => ['../../test/cosim_array.sv'];
+
+  CosimArrayMod(
+    Logic a, {
+    super.name = 'arraymod',
+    int numUnpackedDimensions = 0,
+  })  : assert(numUnpackedDimensions >= 0 && numUnpackedDimensions <= 2,
+            'only supports 0,1,2'),
+        super(definitionName: 'my_cosim_array_2p${numUnpackedDimensions}u') {
+    final dimensions = [
+      if (numUnpackedDimensions >= 2) 5,
+      if (numUnpackedDimensions >= 1) 4,
+      3,
+    ];
+
+    addInputArray('a', a,
+        dimensions: dimensions,
+        elementWidth: 2,
+        numUnpackedDimensions: numUnpackedDimensions);
+    addOutputArray('b',
+        dimensions: dimensions,
+        elementWidth: 2,
+        numUnpackedDimensions: numUnpackedDimensions);
+  }
+}
+
+Future<void> main() async {
+  tearDown(() async {
+    await Simulator.reset();
+    await Cosim.reset();
+  });
+
+  group('cosim array', () {
+    //TODO: walking ones
+    //TODO: 2xunpacked dims
+
+    test('2 packed, 0 unpacked', () async {
+      final mod = CosimArrayMod(Logic(width: 6));
+      await mod.build();
+
+      const dirName = 'simple_array_2p0u';
+
+      await CosimTestingInfrastructure.connectCosim(dirName);
+
+      final vectors = [
+        Vector({'a': 0}, {'b': 0}),
+        Vector({'a': LogicValue.ofString('01xz10')},
+            {'b': LogicValue.ofString('01xz10')}),
+      ];
+      await SimCompare.checkFunctionalVector(mod, vectors);
+
+      await CosimTestingInfrastructure.cleanupCosim(dirName);
+    });
+
+    test('2 packed, 1 unpacked', () async {
+      final mod = CosimArrayMod(Logic(width: 6 * 4), numUnpackedDimensions: 1);
+      await mod.build();
+
+      const dirName = 'simple_array_2p1u';
+
+      await CosimTestingInfrastructure.connectCosim(dirName);
+
+      final vectors = [
+        Vector({'a': 0}, {'b': 0}),
+        Vector({'a': LogicValue.ofString('01xz10' * 4)},
+            {'b': LogicValue.ofString('01xz10' * 4)}),
+      ];
+      await SimCompare.checkFunctionalVector(mod, vectors);
+
+      await CosimTestingInfrastructure.cleanupCosim(dirName);
+    });
+  });
+}

--- a/test/array_test.dart
+++ b/test/array_test.dart
@@ -51,8 +51,14 @@ Future<void> main() async {
   });
 
   group('cosim array', () {
-    //TODO: walking ones
-    //TODO: 2xunpacked dims
+    List<Vector> walkingOnes(int width) {
+      final vectors = <Vector>[];
+      for (var i = 0; i < width; i++) {
+        final shiftedOne = LogicValue.ofInt(1, width) << i;
+        vectors.add(Vector({'a': shiftedOne}, {'b': shiftedOne}));
+      }
+      return vectors;
+    }
 
     test('2 packed, 0 unpacked', () async {
       final mod = CosimArrayMod(Logic(width: 6));
@@ -66,6 +72,7 @@ Future<void> main() async {
         Vector({'a': 0}, {'b': 0}),
         Vector({'a': LogicValue.ofString('01xz10')},
             {'b': LogicValue.ofString('01xz10')}),
+        ...walkingOnes(6)
       ];
       await SimCompare.checkFunctionalVector(mod, vectors);
 
@@ -84,6 +91,28 @@ Future<void> main() async {
         Vector({'a': 0}, {'b': 0}),
         Vector({'a': LogicValue.ofString('01xz10' * 4)},
             {'b': LogicValue.ofString('01xz10' * 4)}),
+        ...walkingOnes(24),
+      ];
+
+      await SimCompare.checkFunctionalVector(mod, vectors);
+
+      await CosimTestingInfrastructure.cleanupCosim(dirName);
+    });
+
+    test('2 packed, 2 unpacked', () async {
+      final mod =
+          CosimArrayMod(Logic(width: 6 * 4 * 5), numUnpackedDimensions: 2);
+      await mod.build();
+
+      const dirName = 'simple_array_2p2u';
+
+      await CosimTestingInfrastructure.connectCosim(dirName);
+
+      final vectors = [
+        Vector({'a': 0}, {'b': 0}),
+        Vector({'a': LogicValue.ofString('01xz10' * 4 * 5)},
+            {'b': LogicValue.ofString('01xz10' * 4 * 5)}),
+        ...walkingOnes(120),
       ];
       await SimCompare.checkFunctionalVector(mod, vectors);
 

--- a/test/cosim_array.sv
+++ b/test/cosim_array.sv
@@ -1,0 +1,38 @@
+// Copyright (C) 2023 Intel Corporation
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// cosim_array.sv
+// A simple SystemVerilog module for testing cosimulation with arrays.
+//
+// 2022
+// Author: Max Korbel <max.korbel@intel.com>
+
+// 2 packed, 2 unpacked
+module my_cosim_array_2p2u(
+	input  logic[2:0][1:0] a [4:0][3:0],
+	output logic[2:0][1:0] b [4:0][3:0]
+);
+
+assign b = a;
+
+endmodule
+
+// 2 packed, 1 unpacked
+module my_cosim_array_2p1u(
+	input  logic[2:0][1:0] a [3:0],
+	output logic[2:0][1:0] b [3:0]
+);
+
+assign b = a;
+
+endmodule
+
+// 2 packed, 0 unpacked
+module my_cosim_array_2p0u(
+	input  logic[2:0][1:0] a,
+	output logic[2:0][1:0] b
+);
+
+assign b = a;
+
+endmodule

--- a/test/cosim_bus.sv
+++ b/test/cosim_bus.sv
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // cosim_bus.sv
-// A simple SystemVerilog module for testing cosimulation.
+// A simple SystemVerilog module for testing cosimulation with busses.
 //
 // 2022
 // Author: Max Korbel <max.korbel@intel.com>


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

ROHD v0.5.0 supports `LogicArray`s, including as ports, and for both packed and unpacked dimensions.  This PR adds support (and testing) for cosimulating with a SystemVerilog module which has arrays (unpacked and packed, multidimensional) with the rohd-cosim package.

## Related Issue(s)

Fix #32 

## Testing

Added new tests for packed only, 1D unpacked, and 2D unpacked.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No