### PR TITLE
Update default permissions in GH actions

### DIFF
--- a/.github/workflows/general.yml
+++ b/.github/workflows/general.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+# Top-level default, no permissions
+permissions: {}
+
 jobs:
   run-checks:
     name: Run Checks


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

It is safest to put a default permissions in GitHub Actions workflows.

## Related Issue(s)

N/A

## Testing

This PR will test it

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No