### PR TITLE
Fix bug with `None` `dart_command` during interactive debug with no timeout

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -118,7 +118,7 @@ linter:
     - one_member_abstracts
     - only_throw_errors
     - overridden_fields
-    - package_api_docs
+    # - package_api_docs
     - package_names
     - package_prefixed_library_names
     - parameter_assignments
@@ -206,7 +206,7 @@ linter:
     - unnecessary_to_list_in_spreads
     # - unreachable_from_main
     - unrelated_type_equality_checks
-    - unsafe_html
+    # - unsafe_html
     - use_build_context_synchronously
     - use_colored_box
     - use_decorated_box

--- a/lib/src/configs/cosim_config.dart
+++ b/lib/src/configs/cosim_config.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 Intel Corporation
+// Copyright (C) 2022-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // cosim_config.dart
@@ -28,6 +28,20 @@ class CosimConnection {
   ///
   /// Will run [disconnect] when the cosimulation is over.
   CosimConnection(this.socket, {this.disconnect = _defaultDisconnect});
+
+  /// A regular expression for usage in [extractSocketPort].
+  static final _cosimSocketRegex = RegExp(r'ROHD COSIM SOCKET:(\d+)');
+
+  /// Extracts a socket number from a stdout [message] from the cosimulation
+  /// process.  Returns `null` if no socket number is found in [message].
+  static int? extractSocketPort(String message) {
+    final match = _cosimSocketRegex.firstMatch(message);
+    if (match != null) {
+      return int.parse(match.group(1)!);
+    }
+
+    return null;
+  }
 }
 
 /// Configuration information for cosimulation.

--- a/lib/src/configs/cosim_process_config.dart
+++ b/lib/src/configs/cosim_process_config.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 Intel Corporation
+// Copyright (C) 2022-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // cosim_process_config.dart
@@ -85,17 +85,14 @@ abstract class CosimProcessConfig extends CosimConfig {
     }
 
     unawaited(procFuture.then((proc) {
-      final cosimSocketRegex = RegExp(r'ROHD COSIM SOCKET:(\d+)');
-
       proc.stdout.transform(utf8.decoder).forEach((msg) async {
         Cosim.logger?.finest('SIM STDOUT:\n$msg');
         cosimLog(msg);
 
         if (!socketConnectionCompleter.isCompleted) {
-          // look for a string indicating the socket to connect to
-          final match = cosimSocketRegex.firstMatch(msg);
-          if (match != null) {
-            final socketNumber = int.parse(match.group(1)!);
+          final socketNumber = CosimConnection.extractSocketPort(msg);
+
+          if (socketNumber != null) {
             socket = await Socket.connect(
                 InternetAddress.loopbackIPv4, socketNumber);
             socketConnectionCompleter.complete();

--- a/python/rohd_connector.py
+++ b/python/rohd_connector.py
@@ -1,5 +1,5 @@
 """
-Copyright (C) 2022-2024 Intel Corporation
+Copyright (C) 2022-2025 Intel Corporation
 SPDX-License-Identifier: BSD-3-Clause
 
 rohd_connector.py
@@ -169,8 +169,11 @@ class RohdConnector:
 
             if (
                 self.last_message_received_time is not None
-                and (time.time() - self.last_message_received_time)
-                > self.dart_connect_timeout
+                and self.dart_connect_timeout is not None
+                and (
+                    (time.time() - self.last_message_received_time)
+                    > self.dart_connect_timeout
+                )
             ):
                 self._error(
                     "Timeout waiting for Dart messages!  Perhaps the Dart side has hung "

--- a/python/rohd_port_connector.py
+++ b/python/rohd_port_connector.py
@@ -159,8 +159,8 @@ async def launch_on_port(
             await cosim_test_module.setup_connections(dut, connector)
 
     except Exception as exception:
-        traceback.print_exc()
-        fail_msg = f"ERROR: Exception encountered during cosim: {exception}"
+        full_traceback = traceback.format_exc()
+        fail_msg = f"ERROR: Exception encountered during cosim: {exception}\n{full_traceback}"
         print(fail_msg, flush=True)
         connector.shutdown()
         print("ERROR: Test failed due to exception.")

--- a/test/port_stuff/custom_test_module.py
+++ b/test/port_stuff/custom_test_module.py
@@ -1,5 +1,5 @@
 """
-Copyright (C) 2022 Intel Corporation
+Copyright (C) 2022-2025 Intel Corporation
 SPDX-License-Identifier: BSD-3-Clause
 
 custom_test.py
@@ -27,6 +27,8 @@ import cosim_test_module
 dart_fail = os.getenv('DART_FAIL')
 dart_fail_async = os.getenv('DART_FAIL_ASYNC')
 dart_hang = os.getenv('DART_HANG')
+separate_dart_launch = os.getenv('SEPARATE_DART_LAUNCH')
+python_fail = os.getenv('PYTHON_FAIL')
 
 @cocotb.test()
 async def custom_test(dut):
@@ -52,9 +54,11 @@ async def custom_test(dut):
     await rohd_port_connector.launch_on_port(
         cosim_test_module=cosim_test_module,
         dut=dut,
-        # dart_command= None,
-        dart_command = dart_command,
+        dart_command = dart_command if not separate_dart_launch else None,
         log_name='custom_test',
         enable_logging=False,
-        dart_connect_timeout=5,
+        dart_connect_timeout = 5 if not separate_dart_launch else None,
     )
+
+    if python_fail:
+        raise Exception("Python test failure injected")

--- a/test/port_stuff/port_launch.dart
+++ b/test/port_stuff/port_launch.dart
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 Intel Corporation
+// Copyright (C) 2022-2025 Intel Corporation
 // SPDX-License-Identifier: BSD-3-Clause
 //
 // port_launch.dart
@@ -7,8 +7,6 @@
 // 2022 October 27
 // Author: Max Korbel <max.korbel@intel.com>
 
-// ignore_for_file: avoid_print
-
 import 'dart:async';
 
 import 'package:args/args.dart';
@@ -16,7 +14,7 @@ import 'package:logging/logging.dart';
 import 'package:rohd/rohd.dart';
 import 'package:rohd_cosim/rohd_cosim.dart';
 
-void main(List<String> args) async {
+Future<void> main(List<String> args) async {
   final parser = ArgParser()
     ..addOption('port', mandatory: true)
     ..addFlag('fail')
@@ -28,7 +26,7 @@ void main(List<String> args) async {
   final fail = results['fail'] as bool;
   final failAsync = results['failAsync'] as bool;
   final hang = results['hang'] as bool;
-  await runCosim(port, fail: fail, failAsync: failAsync, hang: hang);
+  await runCosim(port, dartFail: fail, failAsync: failAsync, hang: hang);
 }
 
 class BottomMod extends ExternalSystemVerilogModule with Cosim {
@@ -50,34 +48,41 @@ class BottomMod extends ExternalSystemVerilogModule with Cosim {
 const bool enableLogging = true;
 
 Future<void> runCosim(int port,
-    {required bool fail, required bool failAsync, required bool hang}) async {
-  // var portStuffDir = './test/port_stuff/';
-  // var outDirPath = '$portStuffDir/tmp_output/';
-
+    {required bool dartFail,
+    required bool failAsync,
+    required bool hang,
+    bool doPrint = true}) async {
   void expectEqual(dynamic a, dynamic b) {
     if (a != b) {
       throw Exception('$a != $b');
     }
   }
 
-  print('Building module...');
+  void log(String message) {
+    if (doPrint) {
+      // ignore: avoid_print
+      print(message);
+    }
+  }
+
+  log('Building module...');
   final a = Logic();
   final mod = BottomMod(a);
   await mod.build();
 
   if (enableLogging) {
     Logger.root.level = Level.ALL;
-    Logger.root.onRecord.listen(print);
+    Logger.root.onRecord.listen((msg) => log(msg.toString()));
   }
 
-  print('Connecting to cosimulation on port $port...');
+  log('Connecting to cosimulation on port $port...');
   await Cosim.connectCosimulation(
       CosimPortConfig(port, enableLogging: enableLogging));
 
-  print('Starting simulation...');
+  log('Starting simulation...');
 
   mod.aBar.changed.listen((event) {
-    print('checking @ ${Simulator.time}');
+    log('checking @ ${Simulator.time}');
     if (Simulator.time == 2) {
       expectEqual(event.newValue, LogicValue.zero);
     } else if (Simulator.time == 4) {
@@ -88,31 +93,31 @@ Future<void> runCosim(int port,
   });
 
   Simulator.registerAction(2, () {
-    print('putting 1');
+    log('putting 1');
     a.put(1);
   });
   Simulator.registerAction(4, () {
-    print('putting 0');
+    log('putting 0');
     a.put(0);
   });
 
-  if (fail) {
-    print('Setting up to fail on the dart side.');
+  if (dartFail) {
+    log('Setting up to fail on the dart side.');
     Simulator.registerAction(3, () {
       throw Exception('Failure intentionally injected');
     });
   }
 
   if (failAsync) {
-    print('Setting up to async fail on the dart side.');
+    log('Setting up to async fail on the dart side.');
     unawaited(a.changed.first.then(
         (value) => throw Exception('Async failure intentionally injected')));
   }
 
   if (hang) {
-    print('Setting up to hang on the dart side.');
+    log('Setting up to hang on the dart side.');
     Simulator.registerAction(3, () async {
-      print('About to hang...');
+      log('About to hang...');
       Simulator.injectAction(() async {
         await Future<void>.delayed(const Duration(seconds: 10));
       });
@@ -120,12 +125,12 @@ Future<void> runCosim(int port,
   }
 
   Simulator.registerEndOfSimulationAction(() {
-    print('End of ROHD Simulation!');
+    log('End of ROHD Simulation!');
   });
 
-  print('Done setting up vectors, launching simulation!');
+  log('Done setting up vectors, launching simulation!');
 
   await Simulator.run();
 
-  print('Simulation has completed!');
+  log('Simulation has completed!');
 }


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

When `None` is passed for `dart_command` in order to perform interactive debug of the Dart process in cosimulation with the SystemVerilog simulator, there was a bug where the timeout variable was still used even if it was set to `None` as well.  This caused a crash in python.

This PR
- fixes the bug, so that the combination of `dart_command = None` and `dart_connect_timeout = None` works properly with the `rohd_port_connector.py`
- adds tests to cover this bug fix
- adds tests to cover that python crashing shows up as a failure in the output logs
- improves python error logging to print the stack trace that led to the error when it occurs within the rohd-cosim python infrastructure
- exposed the `extractSocketPort` function on `CosimConnection` so that it can be reused to extract port information from the stdout of the cosimulation process

## Related Issue(s)

N/A

## Testing

Added new tests, existing tests cover things

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No, just bug fixes, API improvements, and error logging enhancements

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

No, API docs are minorly updated