### PR TITLE
Necessary Support for Newer Linux Distros

### DIFF
--- a/lib/src/configs/cosim_wrap_config.dart
+++ b/lib/src/configs/cosim_wrap_config.dart
@@ -145,10 +145,12 @@ class CosimWrapConfig extends CosimProcessConfig {
         ],
         environment: {
           if (environment != null) ...environment!,
-          'PATH':
-              '${Directory(directory).absolute.path}/$_cosimVEnvName/bin:${Platform.environment['PATH']}',
-          'PYTHON3':
-              '${Directory(directory).absolute.path}/$_cosimVEnvName/bin/python3',
+          if (usePythonVirtualEnvironment)
+            'PATH':
+                '${Directory(directory).absolute.path}/$_cosimVEnvName/bin:${Platform.environment['PATH']}',
+          if (usePythonVirtualEnvironment)
+            'PYTHON3':
+                '${Directory(directory).absolute.path}/$_cosimVEnvName/bin/python3',
         },
         // environment: environment,
       );

--- a/test/bus_test.dart
+++ b/test/bus_test.dart
@@ -52,5 +52,24 @@ Future<void> main() async {
       ];
       await SimCompare.checkFunctionalVector(mod, vectors);
     });
+
+    test('simple bus - no Python venv', () async {
+      final mod = CosimBusMod(Logic(width: 4));
+      await mod.build();
+
+      const dirName = 'simple_bus';
+
+      await CosimTestingInfrastructure.connectCosim(dirName,
+          systemVerilogSimulator: sim, usePythonVirtualEnvironment: false);
+
+      final vectors = [
+        Vector({'a': 0}, {'b': 0}),
+        Vector({'a': 0x3}, {'b': 0x3}),
+        if (sim != SystemVerilogSimulator.verilator)
+          Vector({'a': LogicValue.ofString('01xz')},
+              {'b': LogicValue.ofString('01xz')}),
+      ];
+      await SimCompare.checkFunctionalVector(mod, vectors);
+    });
   });
 }

--- a/test/cosim_test_infra.dart
+++ b/test/cosim_test_infra.dart
@@ -25,12 +25,16 @@ abstract class CosimTestingInfrastructure {
   ///
   /// Make sure to call [cleanupCosim] afterwards.  If you set
   /// [cleanupAfterSimulationEnds] it will do it automatically for you.
+  /// [usePythonVirtualEnvironment] and [cocotbVersion] control how the Cosim
+  /// interacts with the host environment.
   static Future<void> connectCosim(
     String testName, {
     required SystemVerilogSimulator systemVerilogSimulator,
     bool enableLogging = false,
     bool dumpWaves = false,
     bool cleanupAfterSimulationEnds = true,
+    bool usePythonVirtualEnvironment = true,
+    String cocotbVersion = '1.9.2',
   }) async {
     if (enableLogging) {
       Logger.root.level = Level.ALL;
@@ -43,6 +47,8 @@ abstract class CosimTestingInfrastructure {
       directory: tempDirName(testName, systemVerilogSimulator),
       enableLogging: enableLogging,
       dumpWaves: dumpWaves,
+      usePythonVirtualEnvironment: usePythonVirtualEnvironment,
+      cocotbVersion: cocotbVersion,
     ));
 
     if (cleanupAfterSimulationEnds) {


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Newer Linux distros complain about installing things globally via pip. This is problematic for hard dependencies of Cosim like cocotb. This PR introduces Python virtual environments into the Cosim flow to make these newer distros happy.

## Related Issue(s)

N/A

## Testing

All testing is theoretical transparent in the existing tests as the change should be fully backwards compatible. But if more explicit testing is desired, it can be added.

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

Not a breaking change. Everything should still work on older systems too. We are just using a Python virtual environment.

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

Not doc updates for now but some might be warranted?