### PR TITLE
Conditional cosimulation

### DIFF
--- a/lib/src/configs/cosim_wrap_config.dart
+++ b/lib/src/configs/cosim_wrap_config.dart
@@ -9,6 +9,7 @@
 
 import 'dart:io';
 
+import 'package:rohd/rohd.dart';
 import 'package:rohd_cosim/rohd_cosim.dart';
 
 /// A selection of a type of SystemVerilog Simulator.
@@ -139,16 +140,29 @@ class CosimWrapConfig extends CosimProcessConfig {
       {String? dumpWavesString}) {
     final wrapperVerilog = [
       'module $_wrapperName();',
-      ...registrees.entries
-          .map((registreeEntry) => registreeEntry.value.instantiationVerilog(
-                'dont_care',
-                registreeEntry.key,
-                {
-                  ...registreeEntry.value.inputs,
-                  ...registreeEntry.value.outputs,
-                  ...registreeEntry.value.inOuts,
-                }.map((key, value) => MapEntry(key, '')),
-              )),
+      ...registrees.entries.map((registreeEntry) {
+        const instanceType = 'dont_care';
+        final instanceName = registreeEntry.key;
+        final module = registreeEntry.value;
+        final ports = {
+          ...registreeEntry.value.inputs,
+          ...registreeEntry.value.outputs,
+          ...registreeEntry.value.inOuts,
+        }.map((key, value) => MapEntry(key, ''));
+
+        return module.instantiationVerilog(
+              instanceType,
+              instanceName,
+              ports,
+            ) ??
+            SystemVerilogSynthesizer.instantiationVerilogFor(
+              module: module,
+              instanceType: instanceType,
+              instanceName: instanceName,
+              ports: ports,
+              forceStandardInstantiation: true,
+            );
+      }),
       if (dumpWavesString != null) dumpWavesString,
       'endmodule'
     ].join('\n');

--- a/lib/src/configs/cosim_wrap_config.dart
+++ b/lib/src/configs/cosim_wrap_config.dart
@@ -141,9 +141,9 @@ class CosimWrapConfig extends CosimProcessConfig {
     final wrapperVerilog = [
       'module $_wrapperName();',
       ...registrees.entries.map((registreeEntry) {
-        const instanceType = 'dont_care';
         final instanceName = registreeEntry.key;
         final module = registreeEntry.value;
+        final instanceType = module.definitionName;
         final ports = {
           ...registreeEntry.value.inputs,
           ...registreeEntry.value.outputs,

--- a/lib/src/cosim.dart
+++ b/lib/src/cosim.dart
@@ -72,7 +72,7 @@ class _CosimMessage {
 /// When applied to a [ExternalSystemVerilogModule], will configure it so that
 /// it can be cosimulated in a SystemVerilog simulator along with the ROHD
 /// simulator.
-mixin Cosim on ExternalSystemVerilogModule {
+mixin Cosim on SystemVerilog {
   /// A list of verilog source files to include in the build.
   ///
   /// The contents are put in a Makefile, so environment variables should use
@@ -107,6 +107,13 @@ mixin Cosim on ExternalSystemVerilogModule {
   /// uniquified) name. Override this `get`ter to set the hierarchy of the
   /// module to something else.
   String get cosimHierarchy => registreeName;
+
+  /// If set, then this [Module] will be registered for cosimulation.
+  ///
+  /// This flag can be used to determine whether additional modelling logic or
+  /// design should be generated within the module or if it should be left to
+  /// cosimulation to handle behavior.
+  bool get cosimEnabled => true;
 
   /// Resets all context for cosimulation.
   ///
@@ -163,7 +170,9 @@ mixin Cosim on ExternalSystemVerilogModule {
 
   @override
   Future<void> build() async {
-    cosimRegister();
+    if (cosimEnabled) {
+      cosimRegister();
+    }
     await super.build();
   }
 


### PR DESCRIPTION
<!-- Please make sure you check out the contribution guidelines before submitting a pull request! -->

## Description & Motivation

Sometimes it is desirable to be able to have multiple implementations of a module, one with ROHD and one with SystemVerilog, and reuse the same testbench for both.  Currently, you need to point to `ExternalSystemVerilogModule`, which is a base type, which makes it annoying and inconvenient for that type of testbench setup.

This PR introduces an ability to conditionally enable cosim on a module, as well as point to any `Module` with a `SystemVerilog` mixin applied.

## Related Issue(s)

Fix #43

## Testing

TODO: need to add more testing for this

## Backwards-compatibility

> Is this a breaking change that will not be backwards-compatible? If yes, how so?

No

## Documentation

> Does the change require any updates to documentation? If so, where? Are they included?

TODO: Yes, we should include some examples and documentation for this approach.